### PR TITLE
add an buildkite pipeline (and workflow inputs) to allow replay CI only run the replay browser tests

### DIFF
--- a/.buildkite/runtime-tests.sh
+++ b/.buildkite/runtime-tests.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -eu
+
+buildkite-agent artifact download build_id/linux/x86_64/build_id ./ --build "$BUILDKITE_TRIGGERED_FROM_BUILD_ID"
+BUILD_ID=$(cat build_id/linux/x86_64/build_id)
+
+RUN_ID="$BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG/$BUILDKITE_TRIGGERED_FROM_BUILD_NUMBER"
+
+if [ -z "${GITHUB_AUTH_SECRET-}" ]; then
+    echo "GITHUB_AUTH_SECRET is not set in environment"
+    exit 1
+fi
+
+INPUTS='{"ref":"'${BUILDKITE_BRANCH}'","inputs":{"runId":"'${RUN_ID}'","replayBrowserOnly":true,"chromium-build-id":"'${BUILD_ID}'"}}'
+echo 'Running metabase tests on GitHub with inputs: '${INPUTS}
+
+curl -L -s \
+    -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${GITHUB_AUTH_SECRET}" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    https://api.github.com/repos/replayio-public/metabase/actions/workflows/e2e-tests.yml/dispatches \
+    -d ${INPUTS}
+
+
+# and now we wait for a maximum of ITER_COUNT, sleeping SLEEP_SEC_PER_ITER per iteration, polling
+# the GH api to get the build status.
+
+# these values should give us ~50 minutes of wait time, which should be wayyy more than enough (previous
+# runs have taken ~35 minutes)
+SLEEP_SEC_PER_ITER=60
+ITER_COUNT=50
+
+EXPECTED_RUN_NAME="E2E Tests (aggregate) - run id ${RUN_ID}"
+echo "Expected workflow run name: ${EXPECTED_RUN_NAME}"
+
+iter=0
+url_annotation_done=""
+
+while [[ $iter -le $ITER_COUNT ]]; do
+  iter=$(( iter + 1 ))
+  echo "Iteration ${iter}, sleeping for ${SLEEP_SEC_PER_ITER} seconds..."
+  sleep $SLEEP_SEC_PER_ITER
+
+  RUN_JSON=$(curl -L -s \
+    -X GET \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${GITHUB_AUTH_SECRET}" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    https://api.github.com/repos/replayio-public/metabase/actions/runs\?event\=workflow_dispatch | jq -r ".workflow_runs[] | select(.name==\"${EXPECTED_RUN_NAME}\")")
+
+  if [[ -n "$RUN_JSON" ]]; then
+    RUN_STATUS=$(echo "${RUN_JSON}" | jq -r .status)
+    RUN_CONCLUSION=$(echo "${RUN_JSON}" | jq -r .conclusion)
+    RUN_URL=$(echo "${RUN_JSON}" | jq -r .html_url)
+
+    if [[ -z "${url_annotation_done}" ]]; then
+      url_annotation_done="yes"
+      echo "Github workflow run url: ${RUN_URL}"
+      if [ -n "${BUILDKITE}" ]; then
+        buildkite-agent annotate --context tests "${RUN_URL}"
+      fi
+    fi
+
+    if [[ $RUN_STATUS == "completed" ]]; then
+      echo "Github workflow completed with conclusion: ${RUN_CONCLUSION}"
+      if [[ $RUN_CONCLUSION == "success" ]]; then
+        # reflect the success status back to build kite
+        exit 0
+      else
+        exit -1
+      fi
+    else
+      echo "Run status was ${RUN_STATUS}, continuing to poll..."
+    fi
+  else
+    echo "Run '${EXPECTED_RUN_NAME}' not present in workflow run list"
+  fi
+done
+
+echo "GH workflow run didn't complete in time.  failing this step."
+echo "If builds need to take longer, increase the iteration count or sleep time per iteration"
+exit -1

--- a/.buildkite/runtime-tests.yml
+++ b/.buildkite/runtime-tests.yml
@@ -1,0 +1,40 @@
+steps:
+  - label: "Run Metabase tests (Linux) (x86_64)"
+    key: "metabase-tests-linux_x86_64"
+    command: "./.buildkite/runtime-tests.sh"
+    agents:
+      - "deploy=true"
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          region: us-east-2
+          env:
+            FLY_API_TOKEN: "prod/fly-api-token"
+            BUILDKITE_AGENT_TOKEN: "prod/buildkite-agent-token"
+            SSH_PRIVATE_RSA_KEY_B64: "prod/buildkite-ssh-private-key"
+            TAILSCALE_AUTHKEY: "dev/fly-e2e-test-runner-tailscale-auth-key"
+            HASURA_ADMIN_SECRET: "prod/hasura-admin-secret"
+            BUILD_USER_ACCESS_KEY_ID:
+              secret-id: "prod/build-user"
+              json-key: ".access_key_id"
+            BUILD_USER_SECRET_ACCESS_KEY:
+              secret-id: "prod/build-user"
+              json-key: ".secret_access_key"
+            BUILDEVENT_APIKEY: honeycomb-api-key
+            GITHUB_AUTH_SECRET: "prod/metabase-github-secret"
+            BUILDEVENT_APIKEY: honeycomb-api-key
+            BUILDEVENT_BUILDKITE_API_TOKEN: buildkite-api-token-honeycomb-build-events
+      - replayio/buildevents#adb8a05: ~
+      - "ssh://git@github.com/replayio/fly-buildkite-plugin.git#v0.75":
+          image: "registry.fly.io/buildkite-backend-e2e-tests:v14"
+          organization: "replay"
+          cpus: 1
+          memory: 2048
+          secrets:
+            GITHUB_AUTH_SECRET: GITHUB_AUTH_SECRET
+            BUILDKITE_AGENT_TOKEN: BUILDKITE_AGENT_TOKEN
+            SSH_PRIVATE_RSA_KEY_B64: SSH_PRIVATE_RSA_KEY_B64
+            FLY_API_TOKEN: FLY_API_TOKEN
+            TAILSCALE_AUTHKEY: TAILSCALE_AUTHKEY
+            HASURA_ADMIN_SECRET: HASURA_ADMIN_SECRET
+            AWS_SECRET_ACCESS_KEY: BUILD_USER_SECRET_ACCESS_KEY
+            AWS_ACCESS_KEY_ID: BUILD_USER_ACCESS_KEY_ID

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,6 +21,10 @@ on:
         type: string
       runId:
         description: "Test Run ID, chosen by workflow dispatcher, to make it possible to find the correct run from the api"
+        type: string
+      replayBrowserOnly:
+        description: "Only run the e2e tests using the replay browser (e.g. for replay CI)"
+        type: boolean
       folders:
         description: "Folders to run"
         type: string
@@ -171,7 +175,7 @@ jobs:
         run: npx @replayio/cypress install
 
       - name: 1) Run EE Cypress tests on ${{ matrix.folder }}
-        if: ${{ !inputs.runId }}
+        if: ${{ !inputs.replayBrowserOnly }}
         run: |
           yarn run test-cypress-run \
           --env grepTags="-@OSS" \
@@ -181,7 +185,7 @@ jobs:
           CYPRESS_REPLAYIO_ENABLED: 1
 
       - name: 2) Run EE Cypress tests on ${{ matrix.folder }} with Video
-        if: ${{ !inputs.runId }}
+        if: ${{ !inputs.replayBrowserOnly }}
         run: |
           yarn run test-cypress-run \
           --env grepTags="-@OSS" \

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -171,7 +171,7 @@ jobs:
         run: npx @replayio/cypress install
 
       - name: 1) Run EE Cypress tests on ${{ matrix.folder }}
-        if: always()
+        if: ${{ !inputs.runId }}
         run: |
           yarn run test-cypress-run \
           --env grepTags="-@OSS" \
@@ -181,7 +181,7 @@ jobs:
           CYPRESS_REPLAYIO_ENABLED: 1
 
       - name: 2) Run EE Cypress tests on ${{ matrix.folder }} with Video
-        if: always()
+        if: ${{ !inputs.runId }}
         run: |
           yarn run test-cypress-run \
           --env grepTags="-@OSS" \


### PR DESCRIPTION
disable the non-replay browser tests to save some time and reduce the amount of incidental red builds, when we're triggering this workflow from a chromium CI build.

also add a buildkite pipeline so we can await the github action from within a flyvm (and not tie up a BK agent.)