### PR TITLE
we need backticks, not double quotes here

### DIFF
--- a/.buildkite/runtime-tests.mjs
+++ b/.buildkite/runtime-tests.mjs
@@ -347,7 +347,7 @@ function formatFailures(job_name, failures) {
 
 function formatFailureMissingReport(job_name) {
   return (
-    "## ${job_name} failed without a report\n" +
+    `## ${job_name} failed without a report\n` +
     "This likely means the recorder crashed for all tests, so there were no report to upload."
   )
 }


### PR DESCRIPTION
otherwise we get giant a `${job_name}` in buildkite